### PR TITLE
JNI/Android: Add drafts of Application.mk and Android.mk 

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := llama2.c
+LOCAL_MODULE_FILENAME := libllama2c
+LOCAL_SRC_FILES := \
+    ../api.c \
+	../sampler.c \
+	../tokenizer.c \
+	../transformer.c \
+	../util.c
+
+LOCAL_LDLIBS := -lm
+LOCAL_CFLAGS += -fopenmp
+LOCAL_LDFLAGS += -fopenmp
+
+include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,0 +1,3 @@
+# Set target ABI in build.gradle (externalNativeBuild - abiFilters)
+APP_ABI := armeabi-v7a arm64-v8a x86_64
+APP_PLATFORM := latest


### PR DESCRIPTION
This patch enables ndk-build support by adding drafts of the Application.mk and Android.mk files into the jni sub-directory.

Signed-off-by: Wook Song <wook16.song@samsung.com>

```bash
ndk-build NDK_APPLICATION_PATH=$(pwd)/jni/Application.mk
```