### PR TITLE
Build/Meson: Generate pkg-config files for shared libraries

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,12 @@
+llama2c_common_headers = files(
+    'api.h',
+    'sampler.h',
+    'tokenizer.h',
+)
+llama2c_headers = files('transformer.h')
+llama2cq_headers = files('transformer_quantized.h')
+
+install_headers(
+    [llama2c_common_headers, llama2c_headers, llama2cq_headers],
+    install_dir: llama2c_install_includedir,
+)

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,12 @@ libm_dep = cc.find_library('m')
 
 deps = [libm_dep]
 
+llama2c_install_prefix = get_option('prefix')
+llama2c_install_libdir = join_paths(llama2c_install_prefix, get_option('libdir'))
+llama2c_install_includedir = join_paths(llama2c_install_prefix, get_option('includedir'))
+
+subdir('include')
+
 # TODO: Build for Windows is not supported yet.
 if target_machine.system() == 'windows'
   src_run += files('win.c')
@@ -35,10 +41,28 @@ src_llama2_quantized = src_core + files('transformer_quantized.c')
 
 libllama2c = shared_library('llama2c',
     src_llama2,
+    install: true,
+    install_dir: llama2c_install_libdir,
     dependencies: deps)
+
 libllama2cq = shared_library('llama2cq',
     src_llama2_quantized,
+    install: true,
+    install_dir: llama2c_install_libdir,
     dependencies: deps)
+
+pkgconfig_module = import ('pkgconfig')
+pkgconfig_module.generate(
+  name: 'llama2c',
+  description: 'Inference Llama 2 in one file of pure C',
+  libraries: [libllama2c, deps]
+)
+
+pkgconfig_module.generate(
+  name: 'llama2cq',
+  description: 'Inference Llama 2 in one file of pure C (quantized)',
+  libraries: [libllama2c, deps],
+)
 
 opt_gen_bin = get_option('generate-executables')
 if opt_gen_bin.contains('all')


### PR DESCRIPTION
This patch updates the meson build script to generate pkg-config files for providing llama2c development kits. The installation of the required files has also been revised.

Signed-off-by: Wook Song <wook16.song@samsung.com>

#### How To
```
$ meson setup build --prefix=$(pwd)/out
The Meson build system
Version: 1.5.1
Source dir: /home/wook/Work/LLM/llama2.c
Build dir: /home/wook/Work/LLM/llama2.c/build
Build type: native build
Project name: llama2.c
Project version: 0.2024.05.30
C compiler for the host machine: cc (gcc 12.3.0 "cc (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0")
C linker for the host machine: cc ld.bfd 2.38
Host machine cpu family: x86_64
Host machine cpu: x86_64
Run-time dependency OpenMP found: YES 4.5
Library m found: YES
Found pkg-config: YES (/usr/bin/pkg-config) 0.29.2
Build targets in project: 4

llama2.c 0.2024.05.30

  User defined options
    prefix: /home/wook/Work/LLM/llama2.c/out

Found ninja-1.10.1 at /usr/bin/ninja
```
```
$ meson install -C build
ninja: Entering directory `/home/wook/Work/LLM/llama2.c/build'
[18/18] Linking target runq
Installing libllama2c.so to /home/wook/Work/LLM/llama2.c/out/lib/x86_64-linux-gnu
Installing libllama2cq.so to /home/wook/Work/LLM/llama2.c/out/lib/x86_64-linux-gnu
Installing /home/wook/Work/LLM/llama2.c/include/api.h to /home/wook/Work/LLM/llama2.c/out/include
Installing /home/wook/Work/LLM/llama2.c/include/sampler.h to /home/wook/Work/LLM/llama2.c/out/include
Installing /home/wook/Work/LLM/llama2.c/include/tokenizer.h to /home/wook/Work/LLM/llama2.c/out/include
Installing /home/wook/Work/LLM/llama2.c/include/transformer.h to /home/wook/Work/LLM/llama2.c/out/include
Installing /home/wook/Work/LLM/llama2.c/include/transformer_quantized.h to /home/wook/Work/LLM/llama2.c/out/include
Installing /home/wook/Work/LLM/llama2.c/build/meson-private/llama2c.pc to /home/wook/Work/LLM/llama2.c/out/lib/x86_64-linux-gnu/pkgconfig
Installing /home/wook/Work/LLM/llama2.c/build/meson-private/llama2cq.pc to /home/wook/Work/LLM/llama2.c/out/lib/x86_64-linux-gnu/pkgconfig
```

```
$ cat ./out/lib/x86_64-linux-gnu/pkgconfig/llama2c.pc
prefix=/home/wook/Work/LLM/llama2.c/out
includedir=${prefix}/include
libdir=${prefix}/lib/x86_64-linux-gnu

Name: llama2c
Description: Inference Llama 2 in one file of pure C
Version: 0.2024.05.30
Libs: -L${prefix}/lib/x86_64-linux-gnu -lllama2c -lm -fopenmp
Cflags: -I${includedir} -fopenmp
```

```
$ gcc -o llama2c main.c `PKG_CONFIG_PATH=$(pwd)/out/lib/x86_64-linux-gnu/pkgconfig pkg-config llama2c --libs --cflags`
$ LD_LIBRARY_PATH=$(pwd)/out/lib/x86_64-linux-gnu ./llama2c
Usage:   run <checkpoint> [options]
Example: run model.bin -n 256 -i "Once upon a time"
Options:
  -t <float>  temperature in [0,inf], default 1.0
  -p <float>  p value in top-p (nucleus) sampling in [0,1] default 0.9
  -s <int>    random seed, default time(NULL)
  -n <int>    number of steps to run for, default 256. 0 = max_seq_len
  -i <string> input prompt
  -z <string> optional path to custom tokenizer
  -m <string> mode: generate|chat, default: generate
  -y <string> (optional) system prompt in chat mode
```